### PR TITLE
feat: implement and show late assessment start time for student with late start

### DIFF
--- a/api/router/exam.py
+++ b/api/router/exam.py
@@ -1,9 +1,10 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from sqlmodel import Session, select
 
 from api.dependencies import get_assessment, get_assessment_id, get_session
 from api.models.student import Student
 from api.schemas.exam import AssessmentSpec, AssessmentSummary, Question
+from api.utils import parse_time_string
 
 exam_router = APIRouter(tags=["exam"])
 
@@ -18,8 +19,14 @@ Retrieve the exam summary with user-specific start-time and end-time.
 """,
 )
 def get_summary(
+    student_username: str | None = Query(None),
     assessment: AssessmentSpec = Depends(get_assessment),
 ):
+    if student_username and (
+        delay_start := assessment.delayed_start.get(student_username)
+    ):
+        assessment.begins += parse_time_string(delay_start)
+
     return AssessmentSummary(**assessment.dict())
 
 

--- a/api/schemas/exam.py
+++ b/api/schemas/exam.py
@@ -103,6 +103,7 @@ class AssessmentSpec(SQLModel):
     begins: datetime
     duration: int
     extensions: dict[str, str]
+    delayed_start: dict[str, str]
     labelled_subparts: bool
     rubric: Rubric
     questions: dict[int, Question]

--- a/api/utils.py
+++ b/api/utils.py
@@ -1,4 +1,5 @@
 import re
+from datetime import timedelta
 
 
 def is_single_lowercase_alpha(s: str) -> bool:
@@ -24,3 +25,23 @@ def lowercase_roman_to_int(s: str) -> int:
 
 def lowercase_alpha_to_int(letter):
     return ord(letter.lower()) - ord("a") + 1
+
+
+def parse_time_string(time_string):
+    match = re.match(r"(\d+)\s*(\w+)", time_string)
+    if not match:
+        raise ValueError("Invalid time string format")
+
+    value, unit = match.groups()
+    value = int(value)
+
+    if unit in ["minute", "minutes"]:
+        return timedelta(minutes=value)
+    elif unit in ["second", "seconds"]:
+        return timedelta(seconds=value)
+    elif unit in ["hour", "hours"]:
+        return timedelta(hours=value)
+    elif unit in ["day", "days"]:
+        return timedelta(days=value)
+    else:
+        raise ValueError("Unsupported time unit")

--- a/tests/api/test_exam.py
+++ b/tests/api/test_exam.py
@@ -15,6 +15,22 @@ def test_can_get_summary_for_exam(client):
     assert summary["begins"] == "2019-01-01T08:00:00+00:00"
 
 
+def test_get_assessment_start_time_for_student_without_late_start(client):
+    res = client("simple").get("/summary?student_username=rweasley")
+    assert res.status_code == 200
+    summary = res.json()
+
+    assert summary["begins"] == "2019-01-01T08:00:00+00:00"
+
+
+def test_get_delayed_start_time_for_late_start_student(client):
+    res = client("simple").get("/summary?student_username=hpotter")
+    assert res.status_code == 200
+    summary = res.json()
+
+    assert summary["begins"] == "2019-01-01T08:07:00+00:00"
+
+
 @pytest.mark.parametrize(
     "exam_id, expected_questions", [("simple", 1), ("multiple_questions", 2)]
 )

--- a/tests/test_assessments/multiple_questions/assessment.yaml
+++ b/tests/test_assessments/multiple_questions/assessment.yaml
@@ -6,6 +6,13 @@ alternative codes:
 begins: 2019-01-01T08:00:00Z
 duration: 120
 upload time: 30
+
+delayed_start:
+  hpotter: 7 minutes
+  username1: 20 minutes
+  username2: 13 minutes
+  username3: 25 minutes
+
 extensions:
   username1: 20 minutes
   username2: 13 minutes

--- a/tests/test_assessments/simple/assessment.yaml
+++ b/tests/test_assessments/simple/assessment.yaml
@@ -6,6 +6,12 @@ alternative codes:
 begins: 2019-01-01T08:00:00Z
 duration: 120
 upload time: 30
+
+delayed_start:
+  hpotter: 7 minutes
+  username1: 20 minutes
+  username2: 13 minutes
+  username3: 25 minutes
 extensions:
   username1: 20 minutes
   username2: 13 minutes

--- a/yaml_examples/y2023_12345_exam/assessment.yaml
+++ b/yaml_examples/y2023_12345_exam/assessment.yaml
@@ -6,6 +6,13 @@ alternative codes:
 begins: 2024-07-03T08:00:00Z
 duration: 525600
 upload time: 30
+
+delayed_start:
+  hpotter: 7 minutes
+  username1: 20 minutes
+  username2: 13 minutes
+  username3: 25 minutes
+
 extensions:
     username1: 20 minutes
     username2: 13 minutes


### PR DESCRIPTION
The /summary end point is extended to accept an optional username
GET: /summary?student_username=hpotter

The YAML files now contain new a new keyword of delayed_start e.g.  hpotter: 7 minutes

Where the current user (query string) is included the start time of the assessment is extended if the given username has delayed start time.

It might be better to get the username via authentication?